### PR TITLE
Fixed incorrect type when configuring float precision.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub use crate::{
 pub type Float = f64;
 
 #[cfg(not(feature = "f64"))]
-pub type Float = f64;
+pub type Float = f32;
 
 // Marker traits to make handling generic functions over arrays easier.
 pub trait DataF: Data<Elem = Float> {}
@@ -46,3 +46,19 @@ pub type ArrayBase3F<S> = ArrayBaseF<S, Ix3>;
 pub type Array1F = Array1<Float>;
 pub type Array2F = Array2<Float>;
 pub type Array3F = Array3<Float>;
+
+#[cfg(test)]
+mod tests {
+    use std::any::type_name;
+
+    use super::*;
+
+    #[test]
+    fn test_float_type() {
+        #[cfg(feature = "f64")]
+        assert_eq!(type_name::<Float>(), type_name::<f64>());
+
+        #[cfg(not(feature = "f64"))]
+        assert_eq!(type_name::<Float>(), type_name::<f32>());
+    }
+}


### PR DESCRIPTION
f64 float type was used for both features f64 and not(f64), whereas it was intended for f32 to be used when not(f64), this has been fixed and a regression test (test_float_type) has been added.