### PR TITLE
Added basic WebGPU support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,18 @@ anyhow = "1.0.93"
 downcast-rs = "1.0.93"
 approx = "0.5.1"
 
+# Dependencies for WebGPU support.
+pollster = { version = "0.4.0", features = ["macro"], optional = true }
+flume = { version = "0.11.1", features = ["async"], optional = true}
+wgpu = { version = "23.0.1", optional = true }
+bytemuck = { version = "1.21.0", optional = true }
+
+[dev-dependencies]
+test-log = "0.2.16"
+
 [features]
 f64 = []
+wgpu = ["dep:wgpu", "dep:bytemuck", "dep:pollster", "dep:flume"]
 
 [profile.opt-dev]
 inherits = "dev"

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,0 +1,12 @@
+#[cfg(test)]
+mod tests {
+    use log::info;
+
+    #[test_log::test(pollster::test)]
+    async fn test_instance() {
+        let instance = wgpu::Instance::new(Default::default());
+        let adapter = instance.request_adapter(&Default::default()).await.unwrap();
+        let adapter_info = adapter.get_info();
+        info!("{}", adapter_info.backend);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ use ndarray::{prelude::*, Data, DataMut};
 pub mod advect;
 pub mod bc;
 pub mod body;
+#[cfg(feature = "wgpu")]
+pub mod gpu;
 pub mod project;
 pub mod system;
 
@@ -24,6 +26,9 @@ pub use crate::{
     project::ProjectGaussSeidel,
     system::{System, SystemBuilder, SystemOp},
 };
+
+#[cfg(all(feature = "f64", feature = "wgpu"))]
+compile_error!("Double precision and GPU support are mutually exclusive");
 
 #[cfg(feature = "f64")]
 pub type Float = f64;


### PR DESCRIPTION
Added dependencies required to use WebGPU, with a new feature (wgpu) that enables WebGPU support. This also includes a smoke test to ensure that wgpu at least can init a device.